### PR TITLE
Compatibility with django-smuggler and new libraries to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -108,7 +108,8 @@ pip install pillow
 pip install django
 pip install django-redis
 pip install celery[redis]
-
+pip install django-allauth
+pip install django-smuggler
 
 Edit the configuration
 ----------------------

--- a/webapp/raippa/settings.py
+++ b/webapp/raippa/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = (
     'courses',
     'stats',
     'feedback',
+    'smuggler',
 )
 
 SITE_ID = 1
@@ -185,3 +186,6 @@ CACHES = {
         }
     }
 }
+
+#Smuggler settings
+SMUGGLER_FIXTURE_DIR = os.path.join(BASE_DIR, 'fixtures')

--- a/webapp/raippa/urls.py
+++ b/webapp/raippa/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 # TODO: Design the url hierarchy from scratch
 urlpatterns = [
+    url(r'^admin/', include('smuggler.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^stats/', include('stats.urls', namespace='stats')),
     url(r'^feedback/', include('feedback.urls', namespace='feedback')),


### PR DESCRIPTION
Added compatibility with django-smuggler which enables dumping and loading fixtures via admin interface. Fixtures can be loaded with http://my.lovelace.url/admin/load. All courses can be dumped with http://my.lovelace.url/admin/courses/dump. Arbitrary dumps are also possible. Also added some new required libraries to INSTALL instructions. 